### PR TITLE
Updated to hapi-17 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
 
 services:
   - mongodb
+
+after_script: "npm run coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
-  - "node"
+  - "8"
+  - "9"
 
 services:
   - mongodb

--- a/index.js
+++ b/index.js
@@ -1,31 +1,29 @@
 'use strict';
 
-exports.register = (server, opts, next) => {
-  if (!opts.collections || !opts.collections.length) {
-    return next();
-  }
-
-  let db;
-
-  if (server.mongo && typeof server.mongo.db === 'object') {
-    db = server.mongo.db;
-  } else {
-    db = server.plugins['hapi-mongodb'].db;
-  }
-  opts.collections.forEach(item => {
-    const collection = db.collection(item);
-    if (!opts.namespace) {
-      server.decorate('server', item, collection);
-    } else {
-      if (!server[opts.namespace]) {
-        server.decorate('server', opts.namespace, {});
-      }
-      server[opts.namespace][item] = collection;
+exports.plugin = {
+  async register(server, opts) {
+    if (!opts.collections || !opts.collections.length) {
+      return;
     }
-  });
-  next();
-};
 
-exports.register.attributes = {
+    let db;
+
+    if (server.mongo && typeof server.mongo.db === 'object') {
+      db = server.mongo.db;
+    } else {
+      db = server.plugins['hapi-mongodb'].db;
+    }
+    opts.collections.forEach(item => {
+      const collection = db.collection(item);
+      if (!opts.namespace) {
+        server.decorate('server', item, collection);
+      } else {
+        if (!server[opts.namespace]) {
+          server.decorate('server', opts.namespace, {});
+        }
+        server[opts.namespace][item] = collection;
+      }
+    });
+  },
   pkg: require('./package.json')
 };

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Helper for hapi-mongodb to decorate server object with collections",
   "main": "index.js",
   "scripts": {
-    "test": "lab -C"
+    "test": "lab --leaks -e test -c ",
+    "coveralls": "lab -r lcov | coveralls"
   },
   "author": "First+Third",
   "license": "MIT",
   "devDependencies": {
     "code": "^5.1.2",
+    "coveralls": "^3.0.0",
     "eslint": "^3.9.1",
     "eslint-config-firstandthird": "^3.0.2",
     "eslint-plugin-import": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Helper for hapi-mongodb to decorate server object with collections",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "lab -C"
   },
   "author": "First+Third",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^3.5.0",
+    "code": "^5.1.2",
     "eslint": "^3.9.1",
     "eslint-config-firstandthird": "^3.0.2",
     "eslint-plugin-import": "^2.1.0",
-    "hapi": "^16.0.2",
-    "hapi-mongodb": "^6.2.0",
-    "mocha": "^3.1.2"
+    "hapi": "^17.2.0",
+    "hapi-mongodb": "^7.1.0",
+    "lab": "^15.1.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,95 +1,112 @@
-/* globals describe, before, after, it */
 'use strict';
-const chai = require('chai');
-const assert = chai.assert;
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const code = require('code');
+
 const Hapi = require('hapi');
 
-const launchServer = (server, port, mongoOpts, pluginOpts, done) => {
-  server.connection({ port });
-  server.register([
-    {
-      register: require('hapi-mongodb'),
+lab.experiment('hapi-mongo-collections', () => {
+  // Define the options --
+  const mongoOpts = {
+    url: 'mongodb://localhost:27017/hapimongocoll'
+  };
+  const pluginOpts = {
+    collections: ['testcollection']
+  };
+
+  let server;
+  lab.before(async() => {
+    server = new Hapi.Server({ port: 8080 });  
+
+    await server.register({
+      plugin: require('hapi-mongodb'),
       options: mongoOpts
-    },
-    {
-      register: require('../'),
+    });
+
+    await server.register({
+      plugin: require('../'),
       options: pluginOpts
-    }
-  ], (err) => {
-    if (err) {
-      console.log(err);
-    }
-    assert(err === undefined);
-    server.start((startErr) => {
-      if (startErr) {
-        return done(startErr);
-      }
-      done();
     });
   });
-};
 
-let server;
-const port = 8083;
-const mongoOpts = {
-  url: 'mongodb://localhost:27017',
-  decorate: undefined
-};
-const pluginOpts = {
-  collections: ['testcollection']
-};
-
-describe('hapi-mongodb-collections', () => {
-  before(done => {
-    server = new Hapi.Server();
-    launchServer(server, port, mongoOpts, pluginOpts, done);
+  lab.after(async() => {
+    await server.stop();
   });
 
-  after(done => {
-    server.stop(done);
-  });
-
-  it('should decorate server', done => {
-    assert(typeof server.testcollection === 'object', 'Collection exists');
-    assert(typeof server.testcollection.find === 'function', 'Has functions');
-    done();
+  lab.test('it should decorate the server', () => {
+    code.expect(server.testcollection).to.be.an.object();
+    code.expect(server.testcollection.find).to.be.a.function();
   });
 });
 
-describe('hapi-mongodb-collections decorated', () => {
-  before(done => {
-    server = new Hapi.Server();
-    mongoOpts.decorate = true;
-    launchServer(server, port, mongoOpts, pluginOpts, done);
-  });
-  after(done => {
-    server.stop(done);
+lab.experiment('hapi-mongodb-collections decorated', () => {
+  // Define the options --
+  const mongoOpts = {
+    url: 'mongodb://localhost:27017/hapicollectiondec',
+    decorate: true
+  };
+  const pluginOpts = {
+    collections: ['testcollection']
+  };
+
+  let server;
+  lab.before(async() => {
+    server = new Hapi.Server({ port: 8080 });  
+
+    await server.register({
+      plugin: require('hapi-mongodb'),
+      options: mongoOpts
+    });
+
+    await server.register({
+      plugin: require('../'),
+      options: pluginOpts
+    });
   });
 
-  it('should work', done => {
-    assert(typeof server.testcollection === 'object', 'Collection exists');
-    assert(typeof server.testcollection.find === 'function', 'Has functions');
-    done();
+  lab.after(async() => {
+    await server.stop();
+  });
+
+  lab.test('it should decorate the server as well', () => {
+    code.expect(server.testcollection).to.be.an.object();
+    code.expect(server.testcollection.find).to.be.a.function();
   });
 });
 
-describe('hapi-mongodb-collections namespace', () => {
-  before(done => {
-    server = new Hapi.Server();
-    mongoOpts.decorate = true;
-    pluginOpts.namespace = 'dbCollections';
-    pluginOpts.collections = ['stamps', 'rocks'];
+lab.experiment('hapi-mongodb-collections w/namespace', () => {
+  // Define the options --
+  const mongoOpts = {
+    url: 'mongodb://localhost:27017/hapicollectiondec',
+    decorate: true
+  };
+  const pluginOpts = {
+    collections: ['stamps', 'rocks'],
+    namespace: 'colls'
+  };
 
-    launchServer(server, port, mongoOpts, pluginOpts, done);
-  });
-  after(done => {
-    server.stop(done);
+  let server;
+  lab.before(async() => {
+    server = new Hapi.Server({ port: 8080 });  
+
+    await server.register({
+      plugin: require('hapi-mongodb'),
+      options: mongoOpts
+    });
+
+    await server.register({
+      plugin: require('../'),
+      options: pluginOpts
+    });
   });
 
-  it('should be able to specify a namespace', done => {
-    assert(typeof server.dbCollections.stamps === 'object', 'Collection exists');
-    assert(typeof server.dbCollections.rocks === 'object', 'Multiple collections can be in same namespace');
-    assert(typeof server.dbCollections.stamps.find === 'function', 'Has functions');
-    done();
+  lab.after(async() => {
+    await server.stop();
+  });
+
+  lab.test('it should decorate the server as well', () => {
+    code.expect(server.colls.stamps).to.be.an.object();
+    code.expect(server.colls.rocks).to.be.an.object();
+    code.expect(server.colls.stamps.find).to.be.a.function();
   });
 });


### PR DESCRIPTION
Similar to `hapi-mongo-indexes` Upgraded to hapi-17 compatability and swapped out test framework for `async` / `await` version.